### PR TITLE
fix: ID별 주문목록 분리

### DIFF
--- a/backend/app/order_router.py
+++ b/backend/app/order_router.py
@@ -1,18 +1,49 @@
 # backend/app/order_router.py
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Request
+from bson import ObjectId
 from .database import get_db
-from .models import ORDERS_COL
+from .models import ORDERS_COL, USERS_COL
+from .auth_router import COOKIE_ACCESS
+from .security import decode_token
 from typing import List, Dict, Any
 
 router = APIRouter(prefix="/orders", tags=["orders"])
 
 
-@router.get("")
-async def get_orders(db=Depends(get_db)) -> List[Dict[str, Any]]:
-    """주문 목록 조회"""
+# 현재 사용자 가져오기
+async def get_current_user(
+    request: Request,
+    db=Depends(get_db),
+):
+    token = request.cookies.get(COOKIE_ACCESS)
+    if not token:
+        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+
     try:
-        # 최신 주문부터 정렬
-        cursor = db[ORDERS_COL].find().sort("created_at", -1)
+        payload = decode_token(token)
+        if payload.get("scope") != "access":
+            raise ValueError("Not an access token")
+        user_id = payload["sub"]
+    except Exception:
+        raise HTTPException(status_code=401, detail="토큰이 유효하지 않습니다.")
+
+    user = await db[USERS_COL].find_one({"_id": ObjectId(user_id)})
+    if not user:
+        raise HTTPException(status_code=401, detail="사용자를 찾을 수 없습니다.")
+
+    user["_id"] = str(user["_id"])
+    return user
+
+
+@router.get("")
+async def get_orders(
+    current_user: dict = Depends(get_current_user),
+    db=Depends(get_db)
+) -> List[Dict[str, Any]]:
+    """현재 사용자의 주문 목록 조회"""
+    try:
+        # 현재 사용자의 주문만 조회, 최신 주문부터 정렬
+        cursor = db[ORDERS_COL].find({"user_id": current_user["_id"]}).sort("created_at", -1)
         orders = await cursor.to_list(length=100)  # 최대 100개
 
         # MongoDB의 _id를 문자열로 변환
@@ -25,10 +56,17 @@ async def get_orders(db=Depends(get_db)) -> List[Dict[str, Any]]:
 
 
 @router.get("/{order_id}")
-async def get_order(order_id: str, db=Depends(get_db)) -> Dict[str, Any]:
-    """특정 주문 상세 조회"""
+async def get_order(
+    order_id: str,
+    current_user: dict = Depends(get_current_user),
+    db=Depends(get_db)
+) -> Dict[str, Any]:
+    """특정 주문 상세 조회 (본인 주문만)"""
     try:
-        order = await db[ORDERS_COL].find_one({"order_id": order_id})
+        order = await db[ORDERS_COL].find_one({
+            "order_id": order_id,
+            "user_id": current_user["_id"]  # 본인 주문만 조회
+        })
 
         if not order:
             raise HTTPException(404, "주문을 찾을 수 없습니다")

--- a/frontend/src/components/CartPage.tsx
+++ b/frontend/src/components/CartPage.tsx
@@ -153,6 +153,7 @@ export function CartPage() {
           headers: {
             "Content-Type": "application/json",
           },
+          credentials: "include", // 쿠키 전송을 위해 필요
           body: JSON.stringify({
             amount: totals.total,
             order_name: orderName,


### PR DESCRIPTION
### 수정 내역 
 1. payment_router.py

  - get_current_user 함수 추가 (25-46줄)
  - 주문 생성 시 user_id 저장 (87줄)
  - 결제 승인 후 DB 저장 시 user_id 포함 (138줄)

  2. order_router.py

  - get_current_user 함수 추가 (14-35줄)
  - 주문 목록 조회 시 현재 사용자만 필터링 (46줄)
  - 주문 상세 조회 시 본인 주문만 조회 (68줄)

### 작동 방식

  1. 로그인 시 쿠키에 access_token 저장
  2. 주문 생성/조회 시 토큰에서 user_id 추출
  3. 주문 저장 시 user_id 포함
  4. 주문 조회 시 user_id로 필터링