### PR TITLE
feat: 적립금 계산 로직 구현

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -25,6 +25,7 @@ class UserOut(BaseModel):
     phone: str | None = None
     address: str | None = None
     role: str = "user"
+    points: int = 0  # 적립금
 
 
 class BasicResp(BaseModel):

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -119,7 +119,7 @@ export function MyPage() {
               <div>
                 <p className="text-xs text-gray-500">적립금</p>
                 <p className="mt-1 text-base font-semibold text-gray-900">
-                  12,500P
+                  {(currentUser?.points || 0).toLocaleString()}P
                 </p>
               </div>
               <div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,6 +4,7 @@ export interface User {
   name: string;
   phone: string;
   address: string;
+  points?: number; // 적립금
 }
 
 export interface Product {


### PR DESCRIPTION
 구현 내용

  1. Backend - schemas.py (28줄)

  - UserOut 스키마에 points: int = 0 필드 추가

  2. Backend - auth_router.py (7, 17-31, 81-91줄)

  - ORDERS_COL import 추가
  - calculate_user_points() 함수 생성:
    - 사용자의 PAID 상태 주문 조회
    - 총 주문 금액의 5% 계산
  - 로그인 시 포인트 계산 후 응답에 포함

  3. Frontend - types.ts (7줄)

  - User 인터페이스에 points?: number 필드 추가

  4. Frontend - MyPage.tsx (122줄)

  - 하드코딩된 "12,500P" 제거
  - {(currentUser?.points || 0).toLocaleString()}P로 변경
  
작동 방식

  1. 사용자 로그인 시 백엔드에서 주문 내역 조회
  2. PAID 상태 주문의 총 금액 계산
  3. 5% 적립금 계산 (정수)
  4. 프론트엔드에서 동적으로 표시