### PR TITLE
fix: 상품 상세 페이지 카테고리 네비게이션 수정

### DIFF
--- a/frontend/src/components/ProductDetailPage.tsx
+++ b/frontend/src/components/ProductDetailPage.tsx
@@ -113,7 +113,7 @@ const normalizerProdectDtail = (raw: unknown): Product => {
 export function ProductDetailPage() {
   const navigate = useNavigate();
   const { productId } = useParams<{ productId: string }>();
-  const { addToCart, currentUser } = useAppState();
+  const { addToCart, currentUser, setSelectedCategory, setSearchQuery } = useAppState();
 
   const [product, setProduct] = useState<Product | null>(null);
   const [loading, setLoading] = useState(true);
@@ -199,6 +199,14 @@ export function ProductDetailPage() {
     setSelectedSize(product.sizes?.[0] ?? DEFAULT_SIZE);
   }, [product]);
 
+  const handleCategoryClick = () => {
+    if (product?.category) {
+      setSelectedCategory(product.category);
+      setSearchQuery("");
+      navigate("/products");
+    }
+  };
+
   const handleAddToCart = () => {
     if (!product) {
       toast.error("상품 정보를 불러오지 못했어요.");
@@ -277,7 +285,7 @@ export function ProductDetailPage() {
             홈
           </button>
           <span>/</span>
-          <button type="button" onClick={() => navigate("/products")}>
+          <button type="button" onClick={handleCategoryClick}>
             {product.category}
           </button>
           <span>/</span>


### PR DESCRIPTION
## 요약
  상품 상세 페이지의 카테고리 브레드크럼 네비게이션 기능을 수정했습니다.

  ## 변경 사항
  - 카테고리 브레드크럼 클릭 시 전역 상태 업데이트 추가
  - 클릭 시 해당 카테고리로 필터링된 상품 목록 페이지로 이동하도록 수정
  - Header 및 HomePage의 카테고리 네비게이션 패턴과 일관성 유지

  ## 수정된 파일
  - `frontend/src/components/ProductDetailPage.tsx`