### PR TITLE
Feat: 상품 검색 API에 Redis 캐싱 추가

### DIFF
--- a/backend/app/product_random_router.py
+++ b/backend/app/product_random_router.py
@@ -5,6 +5,7 @@ from typing import Any
 import random
 import json
 import hashlib
+import os
 
 from fastapi import APIRouter, Depends, Query
 from motor.motor_asyncio import AsyncIOMotorDatabase
@@ -117,7 +118,7 @@ async def random_products(
     # Redis 캐시 저장 (TTL: 10분 = 600초)
     if redis_client.redis:
         try:
-            ttl = 600   # 10분
+            ttl = int(os.getenv("REDIS_TTL_RANDOM_PRODUCTS", 600))
             await redis_client.redis.setex(
                 cache_key,
                 ttl,


### PR DESCRIPTION
## 요약
상품 검색 API에 Redis 캐싱을 적용하여 검색 성능을 대폭 개선

## 추가 사항
- 검색 결과를 Redis에 10분간 캐싱
- 페이지별 개별 캐시 키 생성
- 브랜드별 필터를 정렬하여 캐시 히트율 향상
- 캐시 히트/미스 로그 추가

## 수정 파일
- backend/app/product_router.py
  - Redis 클라이언트 import 추가
  - _generate_search_cache_key() 함수 추가
  - search_product() 함수에 캐시 로직 추가

## 로직
- 검색 요청 시 Redis에서 캐시 확인
- 캐시 히트 -> 즉시 응답 반환
- 캐시 미스 -> Elasticsearch 조회 후 Redis에 저장 (TTL: 10분)

## 캐시 키 구조
search:{query}:{category}:{category2}:{brands_sorted}:{minPrice}:{maxPrice}:{sort}:{page}:{limit}

## 기대 효과
- 사용자 경험 개선 (빠른 검색 응답)
- 서버 리소스 절감 (Elasticsearch 부하 감소)
