### PR TITLE
Feat/prompt cache

### DIFF
--- a/backend/app/bedrock_client.py
+++ b/backend/app/bedrock_client.py
@@ -153,13 +153,18 @@ class BedrockClient:
                         self.last_api_call_time = time.time()
 
                         usage = response.get("usage", {})
-                        cache_read = usage.get("cacheReadInputTokenCount", 0)
-                        cache_write = usage.get("cacheCreationInputTokenCount", 0)
-                        
+                        cache_read = usage.get("cacheReadInputTokens", 0)
+                        cache_write = usage.get("cacheWriteInputTokens", 0)
+                        input_tokens = usage.get("inputTokens", 0)
+                        output_tokens = usage.get("outputTokens", 0)
+                        total_tokens = usage.get("totalTokens", 0)
+
                         if cache_read > 0:
-                            logger.info(f"[Bedrock] 💾 Cache HIT - Read: {cache_read} tokens (90% 할인!)")
+                            logger.info(f"[Bedrock] 💾 Prompt Cache HIT ({cache_read:,} tokens cached) | In: {input_tokens:,}, Out: {output_tokens:,}, Total: {total_tokens:,}")
                         elif cache_write > 0:
-                            logger.info(f"[Bedrock] 💾 Cache MISS - Write: {cache_write} tokens")
+                            logger.info(f"[Bedrock] 💾 Prompt Cache MISS (writing {cache_write:,} tokens) | In: {input_tokens:,}, Out: {output_tokens:,}, Total: {total_tokens:,}")
+                        else:
+                            logger.info(f"[Bedrock] 📊 Tokens | In: {input_tokens:,}, Out: {output_tokens:,}, Total: {total_tokens:,}")
                         
                         break
 

--- a/backend/app/bedrock_client.py
+++ b/backend/app/bedrock_client.py
@@ -133,7 +133,8 @@ class BedrockClient:
                             {"text": system_prompt},
                             {"cachePoint": {"type": "default"}}
                         ]
-                        logger.info(f"[Bedrock] Prompt Caching enabled")
+                        if iteration == 1:
+                            logger.info(f"[Bedrock] Prompt Caching enabled")
                     else:
                         request_params["system"] = [{"text": system_prompt}]
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -345,7 +345,8 @@ async def chat(http_request: Request, chat_request: ChatRequest):
             tool_handlers=tool_handlers,
             max_iterations=MAX_TOOL_ITERATIONS,  # 환경 변수로 제어 (기본값: 5)
             temperature=0.7,
-            max_tokens=1000
+            max_tokens=1000,
+            enable_caching=True
         )
 
         reply = result["response"]


### PR DESCRIPTION
  ## Summary
  Claude Prompt Caching을 도입하여 LLM API 비용을 최적화하고, 캐시 상태를 모니터링할 수 있는 로그
  시스템을 구현했습니다.

  ## 주요 변경사항

  ### 기능 추가
  - **Claude Prompt Caching 구현**
    - System Prompt에 `cachePoint` 적용 (5분 TTL)
    - 동일 사용자의 연속 요청 시 시스템 프롬프트 재사용
    - 캐시 히트 시 입력 토큰 비용 절감 효과

  ### 버그 수정
  - **캐시 로그 미출력 문제 해결**
    - API 응답 키 이름 수정: `cacheReadInputTokenCount` → `cacheReadInputTokens`
    - Bedrock API 실제 응답 형식에 맞춰 수정

  ### 개선사항
  - **로그 가독성 개선**
    - Usage 정보와 캐시 상태를 한 줄로 통합
    - 명확한 캐시 상태 표시: "Prompt Cache HIT/MISS"

  **로그 예시:**
  [Bedrock] 💾 Prompt Cache HIT (8,185 tokens cached) | In: 338, Out: 98, Total: 8,621
  [Bedrock] 💾 Prompt Cache MISS (writing 8,185 tokens) | In: 338, Out: 98, Total: 8,621
  [Bedrock] 📊 Tokens | In: 338, Out: 98, Total: 8,621

  ## 관련 파일
  - `backend/app/bedrock_client.py`: 캐싱 로직 및 로그 개선
  - `backend/app/main.py`: `enable_caching=True` 설정
