### PR TITLE
feat: product list page 좌측 필터

### DIFF
--- a/frontend/src/components/ProductListPage.tsx
+++ b/frontend/src/components/ProductListPage.tsx
@@ -299,11 +299,12 @@ export function ProductListPage() {
             </Select>
           </div>
         </div>
-
-        <div className="grid gap-8 lg:grid-cols-[280px_1fr] lg:gap-12">
+      
+      <div className="grid gap-8 lg:grid-cols-[280px_1fr] lg:gap-12">
+        <div className="lg:sticky lg:top-[150px] self-start">
           <Card
             className={cn(
-              "w-full md:w-64 shrink-0 border-gray-200 bg-brand-main",
+              "w-full md:w-64 shrink-0 border-gray-200 bg-brand-main lg:max-h-[calc(100vh-128px)] lg:overflow-y-auto",
               showFilters ? "block" : "hidden md:block"
             )}>
             <div className="flex items-center justify-between border-b px-5 py-4 ">
@@ -402,6 +403,7 @@ export function ProductListPage() {
               </div>
             </div>
           </Card>
+        </div>
 
           <div className="flex-1">
             {status === "loading" ? (


### PR DESCRIPTION
변경전
- 스크롤을 내릴 시 위에 필터가 고정되어 있어 필터를 걸기 위해서는 다시 위로 향해야 함

변경후
- 왼쪽 필터 컬럼을 sticky top-[150px] 래퍼로 감싸서 헤더 아래에 붙인 뒤, 사용자 스크롤을 따라 내려오도록 만들었음. 따라서 리스트 하단까지 내려가도 필터를 다시 쓰려면 위로 올라갈 필요 없이 곧바로 설정을 바꿀 수 있음.

